### PR TITLE
Remove wrong social_media_url

### DIFF
--- a/KeyClip.podspec
+++ b/KeyClip.podspec
@@ -15,7 +15,6 @@ Pod::Spec.new do |s|
   s.license          = 'MIT'
   s.author           = { "aska" => "s.aska.org@gmail.com" }
   s.source           = { :git => "https://github.com/s-aska/KeyClip.git", :tag => "#{s.version}" }
-  s.social_media_url = 'https://twitter.com/k_katsumi'
 
   s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.9"


### PR DESCRIPTION
You specify wrong `social_media_url` in your podspec. Then CocoaPods new pod feed bot announce your pod with wrong Twitter account . https://twitter.com/CocoaPodsFeed/status/633634262147825664 😅